### PR TITLE
Add single agent loader utility

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,3 +1,8 @@
-from importlib.metadata import version
-__all__ = ["load_all_agents"]
-__version__ = version("crewai")  # convenience
+from importlib.metadata import version, PackageNotFoundError
+from .loader import load_all_agents, load_agent
+
+__all__ = ["load_all_agents", "load_agent"]
+try:  # Optional: CrewAI may not be installed in all dev environments
+    __version__ = version("crewai")
+except PackageNotFoundError:  # pragma: no cover - version lookup is trivial
+    __version__ = "unknown"

--- a/agents/loader.py
+++ b/agents/loader.py
@@ -53,3 +53,22 @@ def load_all_agents(root="agents"):
         agent = _to_wrapper(cfg)
         out[cfg["name"].lower()] = agent
     return out
+
+def load_agent(name: str, root: str = "agents"):
+    """Load a single agent configuration by name.
+
+    Parameters
+    ----------
+    name:
+        Name of the agent (case-insensitive, matches the ``name`` field in YAML).
+    root:
+        Root directory containing agent YAML files. Defaults to ``"agents"``.
+
+    Returns
+    -------
+    object | None
+        The loaded agent wrapper instance or ``None`` if not found.
+    """
+    name = name.lower()
+    agents = load_all_agents(root)
+    return agents.get(name)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,19 @@
+import pytest
+from agents.loader import load_agent
+
+
+def test_load_agent_by_name():
+    agent = load_agent("CEO")
+    assert agent is not None
+    assert agent.name == "CEO"
+
+
+def test_load_agent_case_insensitive():
+    agent = load_agent("vc")
+    assert agent is not None
+    assert agent.name == "VC"
+
+
+def test_load_agent_not_found():
+    missing = load_agent("nonexistent")
+    assert missing is None


### PR DESCRIPTION
## Summary
- implement `load_agent` helper for loading individual agent configs
- export `load_agent` in `agents.__init__`
- add basic unit tests for the new loader

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450d60a6b88329914dbb5b0d7c6953