### PR TITLE
Add synthetic edge case and malicious data generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,5 @@ docker-compose.override.yml
 
 # Generic log files
 *.log
+# Test data cache
+/tests/cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ dev = [
     "pre-commit>=3.6.0",
     "jupyter>=1.0.0",
     "ipython>=8.17.2",
+    "aiohttp>=3.12.0",
+    "aioresponses>=0.7.0",
+    "responses>=0.25.0",
+    "docker>=7.0.0",
 ]
 
 ai = [

--- a/tests/framework/data_manager.py
+++ b/tests/framework/data_manager.py
@@ -158,6 +158,35 @@ class SyntheticDataGenerator:
             'timestamp': self.fake.date_time().isoformat()
         }
 
+    def generate_edge_case(self) -> Dict[str, Any]:
+        """Generate edge case startup idea data with boundary values."""
+        return {
+            'title': '',
+            'description': self.fake.text(max_nb_chars=1024),
+            'category': 'edge',
+            'tags': [],
+            'evidence': '',
+            'status': 'unknown',
+            'created_by': '',
+            'market_size': 0,
+            'target_audience': '',
+            'business_model': '',
+            'competition_level': 'n/a',
+            'implementation_complexity': 0
+        }
+
+    def generate_malicious_payload(self) -> Dict[str, Any]:
+        """Generate malicious payload for security testing."""
+        payloads = [
+            "'; DROP TABLE users; --",
+            "<script>alert('xss')</script>",
+            "../../../../../../etc/passwd"
+        ]
+        return {
+            'payload': self.fake.random_element(payloads),
+            'timestamp': self.fake.date_time().isoformat()
+        }
+
 
 class MockServiceManager:
     """Manages mock services for testing external dependencies."""
@@ -382,11 +411,15 @@ class DataManager:
                 data = [self.synthetic_generator.generate_user_data(anonymized) for _ in range(count)]
             elif schema == 'api_responses':
                 data = [
-                    self.synthetic_generator.generate_api_response(f"/api/test/{i}", 
+                    self.synthetic_generator.generate_api_response(f"/api/test/{i}",
                     success=i % 10 != 0) for i in range(count)
                 ]
             elif schema == 'performance_metrics':
                 data = [self.synthetic_generator.generate_performance_metrics() for _ in range(count)]
+            elif schema == 'edge_cases':
+                data = [self.synthetic_generator.generate_edge_case() for _ in range(count)]
+            elif schema == 'malicious_payloads':
+                data = [self.synthetic_generator.generate_malicious_payload() for _ in range(count)]
             else:
                 raise ValueError(f"Unknown schema type: {schema}")
             
@@ -566,6 +599,18 @@ def create_performance_test_data(count: int = 100) -> TestDataSet:
     """Factory function to create performance metrics test data."""
     manager = DataManager()
     return manager.generate_synthetic_data('performance_metrics', count)
+
+
+def create_edge_case_test_data(count: int = 20) -> TestDataSet:
+    """Factory to create edge case startup idea data."""
+    manager = DataManager()
+    return manager.generate_synthetic_data('edge_cases', count)
+
+
+def create_malicious_payload_data(count: int = 20) -> TestDataSet:
+    """Factory to create malicious payload test data."""
+    manager = DataManager()
+    return manager.generate_synthetic_data('malicious_payloads', count)
 
 
 async def create_mock_api_service(endpoints: List[Dict[str, Any]], port: int = 8080) -> MockServiceConfig:

--- a/tests/test_framework/test_data_generation.py
+++ b/tests/test_framework/test_data_generation.py
@@ -1,0 +1,32 @@
+import pytest
+
+from tests.framework.data_manager import (
+    DataManager,
+    create_edge_case_test_data,
+    create_malicious_payload_data,
+)
+
+
+class TestSyntheticDataGeneration:
+    def test_should_generate_edge_case_data(self):
+        manager = DataManager()
+        dataset = manager.generate_synthetic_data('edge_cases', 3)
+        assert dataset.schema['type'] == 'edge_cases'
+        assert dataset.data['count'] == 3
+        for record in dataset.data['records']:
+            assert record['market_size'] == 0
+            assert record['implementation_complexity'] == 0
+
+    def test_should_generate_malicious_payloads(self):
+        manager = DataManager()
+        dataset = manager.generate_synthetic_data('malicious_payloads', 2)
+        assert dataset.schema['type'] == 'malicious_payloads'
+        assert dataset.data['count'] == 2
+        for record in dataset.data['records']:
+            assert 'payload' in record
+
+    def test_factory_functions(self):
+        edge_dataset = create_edge_case_test_data(1)
+        malicious_dataset = create_malicious_payload_data(1)
+        assert edge_dataset.schema['type'] == 'edge_cases'
+        assert malicious_dataset.schema['type'] == 'malicious_payloads'


### PR DESCRIPTION
## Summary
- extend `SyntheticDataGenerator` with edge case and malicious payload generators
- support new schemas in `DataManager.generate_synthetic_data`
- expose helper factory functions for test data creation
- add unit tests covering new generators
- ignore test data cache in git
- document missing dev dependencies

## Testing
- `pytest -q tests/test_framework/test_data_generation.py`

------
https://chatgpt.com/codex/tasks/task_e_68560494bc3083299ced0b6c7d777fe9